### PR TITLE
Fixed strides not being restored when calling attach_mem_sh

### DIFF
--- a/shared_memory_python.cpp
+++ b/shared_memory_python.cpp
@@ -101,6 +101,7 @@ PyArrayObject * copy_from_buffer_to_numpy_array(char * buffer) {
 		type_num, 
 		(void *) current_pointer
 	);
+	copy_from_pointer_array((npy_intp*)array->strides, (npy_intp*)strides, nd);
 	return array;
 }
 


### PR DESCRIPTION
See issue https://github.com/imaginary-friend94/Shared-Array-for-Windows/issues/1