### PR TITLE
Fix create_mem_sh

### DIFF
--- a/shared_memory_python.cpp
+++ b/shared_memory_python.cpp
@@ -101,7 +101,6 @@ PyArrayObject * copy_from_buffer_to_numpy_array(char * buffer) {
 		type_num, 
 		(void *) current_pointer
 	);
-	copy_from_pointer_array((npy_intp*)array->strides, (npy_intp*)strides, nd);
 	return array;
 }
 
@@ -255,6 +254,7 @@ create_mem_sh(PyObject *self, PyObject *args)
 		PyErr_SetString(PyExc_RuntimeError, "set_mem_sh: parse except");
 	}
 	PyArrayObject * array_for_shrdmem = (PyArrayObject *) pyobj_for_shrdmem;
+	array_for_shrdmem = PyArray_GETCONTIGUOUS(array_for_shrdmem);
 	if (array_for_shrdmem->base != nullptr) {
 		PyErr_SetString(PyExc_RuntimeError, "set_mem_sh: array is not homogeneous");
 	}


### PR DESCRIPTION
Actually the error was related to the function PyArray_SimpleNewFromData. It accepts only (C-style) contiguous numpy array and I was calling create_mem_sh with a (Fortran-style) contiguous, hence the different strides. I removed the line I inserted in last commit since it is not needed anymore and it actually didn't fully fixed the bug and added new code to create_mem_sh function.
Feel free to merge if you want.
Thanks